### PR TITLE
Fix syntax error in analyse.py

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
 
     #昵称
     num_list = [5 for i in range(1,len(NickName_list)+1)]
-    word_cloud('微信好友昵称',NickName_list,num_list,[18,18]])
+    word_cloud('微信好友昵称',NickName_list,num_list,[18,18])
 
     #微信好友签名关键词
     name_list,num_list = counter2list(Signature_counter.most_common(200))


### PR DESCRIPTION
flake8 testing of https://github.com/yangxuanxc/wechat_friends on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./analyse.py:204:55: E999 SyntaxError: invalid syntax
    word_cloud('微信好友昵称',NickName_list,num_list,[18,18]])
                                                      ^
1     E999 SyntaxError: invalid syntax
1
```