### PR TITLE
去掉签名中的表情和<span> <class>标签

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -191,7 +191,8 @@ if __name__ == '__main__':
         #昵称
         NickName_list.append(friend['NickName'])
         #签名关键词提取
-        get_tag(friend['Signature'],Signature_counter)
+        signature=re.sub(r"<([^ ]*).*>(.*)</(.*)>", " ", friend["Signature"])
+        get_tag(signature,Signature_counter)
         
 
     #性别


### PR DESCRIPTION
很多人微信签名会用表情，在程序中被显示为<span class=***>***</span>, 结巴分词没法处理。我用正则表达式直接去掉了